### PR TITLE
publish用のパイプラインテンプレート push時に動くように修正

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,6 +1,5 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
 name: Maven Package
 
 on:
@@ -17,6 +16,7 @@ jobs:
       contents: read
       packages: write
 
+    # TODO image publish先のDockerコンテナなどの準備が必要なので一旦テンプレートの状態そのまま
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11


### PR DESCRIPTION
■PRでのCI起動テスト　一旦maven test を動かす
![image](https://user-images.githubusercontent.com/87862521/133961135-4280ae27-b5fb-40f0-a523-fa62cf191635.png)
